### PR TITLE
Add werf to CI/CD tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ Name | Description
   - [ ] [Drone](https://www.drone.io)
   - [ ] [Tekton](https://cloud.google.com/tekton)
   - [ ] [Argo CD](https://argoproj.github.io/argo-cd)
+  - [ ] [werf](https://werf.io/)
 
 Note: "Provisioning" tools can be used to perform configuration management to some extent. The same applies for configuration management tools, which can be used for pprovisioning.
 


### PR DESCRIPTION
[werf](https://werf.io/) is an Open Source CLI tool for CI/CD. It glues and extends widely used technologies, such as Git, Helm, and Kubernetes, to provide convenience and consistency  (via its Giterminism principle). 